### PR TITLE
Add docs-report-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-report-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-report-template.md
@@ -1,0 +1,16 @@
+---
+name: Documentation report template
+about: Use this template when reporting an issue in the documentation
+
+---
+
+**Version of the documentation**
+
+
+**Page (and section, if applicable) where the issue occurs**
+
+
+**Description of the issue**
+
+
+**Suggested fix**


### PR DESCRIPTION
Adds a documentation-specific issue report template to this repository, since documentation issues have different reporting needs than either bugs or feature requests (i.e. need a link to the page where the issue occurs).

Template is identical to the one we were using in the archivematica-docs repo before the Issues repo was created.

Connected to #8 