### PR TITLE
Clarify documentation and release notes requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -22,4 +22,4 @@ Please make sure these steps are taken before moving this issue from Review to V
 - All PRs related to this issue are properly linked 👍
 - All PRs related to this issue have been merged 👍
 - Test plan for this issue has been implemented and passed 👍
-- Release documentation (e.g. release notes, wiki documentation, etc) regarding this issue has been written 👍
+- Documentation regarding this issue has been written and it has been added to the release notes, if needed 👍

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,4 +23,4 @@ Please make sure these steps are taken before moving this issue from Review to V
 - All PRs related to this issue are properly linked 👍
 - All PRs related to this issue have been merged 👍
 - Test plan for this issue has been implemented and passed 👍
-- Release documentation (e.g. release notes, wiki documentation, etc) regarding this issue has been written 👍
+- Documentation regarding this issue has been written and it has been added to the release notes, if needed 👍


### PR DESCRIPTION
During a recent meeting with @sromkey and @peterVG, we talked about what an analyst is responsible for during QA and agreed that the analyst is responsible for ensuring that the issue is properly documented AND added to the release notes, if needed. I've amended the requirements checklist at the bottom of the bug and feature templates to reflect this.