### PR TITLE
Updated to add padding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -15,6 +15,7 @@ about: Use this template when reporting a bug
 
 **Your environment (version of Archivematica, OS version, etc)**
 
+
 ---
 **For Artefactual use:**
 Please make sure these steps are taken before moving this issue from Review to Verified in Waffle:


### PR DESCRIPTION
Issues sometimes get created with a formatting error - the environment info gets turned into a heading if the next line contains the three dashes. The solution is to add a blank line between the environment info and the three dashes. Adding an extra blank line here might help prevent this.