### PR TITLE
Remove Waffle language and standardize templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -18,7 +18,7 @@ about: Use this template when reporting a bug
 
 ---
 **For Artefactual use:**
-Please make sure these steps are taken before moving this issue from Review to Verified in Waffle:
+Please make sure these steps are taken before moving this issue from Review to Done:
 
 - All PRs related to this issue are properly linked 👍
 - All PRs related to this issue have been merged 👍

--- a/.github/ISSUE_TEMPLATE/feature-request-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-template.md
@@ -18,7 +18,7 @@ about: Suggest an idea for this project
 
 ---
 **For Artefactual use:**
-Please make sure these steps are taken before moving this issue from Review to Verified in Waffle:
+Please make sure these steps are taken before moving this issue from Review to Done:
 
 - All PRs related to this issue are properly linked 👍
 - All PRs related to this issue have been merged 👍


### PR DESCRIPTION
We don't use Waffle anymore! I just simplified the language here to "from Review to Done." And I renamed the feature request template so it matches the other templates.