### PR TITLE
Add AMAUAT step to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist-template.md
@@ -7,24 +7,27 @@ about: Use this checklist prior to each public Archivematica release
 
 The following steps need to be completed to finalize a release of
 Archivematica. Each of the steps below refer to the entries in the Artefactual
-[release day checklist][release-checklist-4]:
+[release day checklist][release-checklist-1]:
 
-- [ ] [Update Archivematica version][release-checklist-1]
-- [ ] [Update Storage Service version][release-checklist-2]
+- [ ] [Update Archivematica version][release-checklist-2]
+- [ ] [Update Storage Service version][release-checklist-3]
 - [ ] Update software repositories (Steps 3, 4, 6)
 - [ ] Update installation instructions (Step 5)
 - [ ] Update website (Step 7)
 - [ ] Change default branch in GitHub/Gitlab (Step 8)
 - [ ] Update am-packbuild (Step 9)
-- [ ] [Release notes][release-checklist-4] (Step 10)
-- [ ] Announcement to Google Group (Step 11)
-- [ ] Close all release-related issues (Step 12)
+- [ ] Release [Archivematica Acceptance Tests][release-checklist-4] (AMAUAT)
+  (Step 10)
+- [ ] [Release notes][release-checklist-5] (Step 11)
+- [ ] Announcement to Google Group (Step 12)
+- [ ] Close all release-related issues (Step 13)
 
 ## References:
 
 * [Release day checklist][release-checklist-4]
 
-[release-checklist-1]: https://github.com/artefactual/archivematica/pull/1374
-[release-checklist-2]: https://github.com/artefactual/archivematica-storage-service/pull/450
-[release-checklist-3]: https://wiki.archivematica.org/Archivematica_1.9.1_and_Storage_Service_0.14.1_release_notes
-[release-checklist-4]: https://wiki.archivematica.org/Release_Process#Release_Day_Checklist
+[release-checklist-1]: https://wiki.archivematica.org/Release_Process#Release_Day_Checklist
+[release-checklist-2]: https://github.com/artefactual/archivematica/pull/1374
+[release-checklist-3]: https://github.com/artefactual/archivematica-storage-service/pull/450
+[release-checklist-4]: https://github.com/artefactual-labs/archivematica-acceptance-tests
+[release-checklist-5]: https://wiki.archivematica.org/Archivematica_1.9.1_and_Storage_Service_0.14.1_release_notes


### PR DESCRIPTION
Ensure that there is a step in the release process that sees us create an automated test suite that is known to pass against a specific version of Archivematica. 

The step has also been added as step 10 to the Archivematica [wiki](https://wiki.archivematica.org/index.php?title=Release_Process&diff=13146&oldid=12853).

Connected to archivematica/issues#778