### PR TITLE
Update issue templates with checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -23,6 +23,6 @@ Before you close this issue, you must check off the following:
 
 - [ ] All pull requests related to this issue are properly linked
 - [ ] All pull requests related to this issue have been merged
-- [ ] A testing plan for this issue has been implemented and passed (please include testing plan details in the comments below)
+- [ ] A testing plan for this issue has been implemented and passed (testing plan information should be included in the issue body or comments)
 - [ ] Documentation regarding this issue has been written and merged
 - [ ] Details about this issue have been added to the release notes (if applicable)

--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -13,14 +13,16 @@ about: Use this template when reporting a bug
 **Steps to reproduce**
 
 
-**Your environment (version of Archivematica, OS version, etc)**
-
+**Your environment (version of Archivematica, operating system, other relevant details)**
 
 ---
-**For Artefactual use:**
-Please make sure these steps are taken before moving this issue from Review to Done:
 
-- All PRs related to this issue are properly linked 👍
-- All PRs related to this issue have been merged 👍
-- Test plan for this issue has been implemented and passed 👍
-- Documentation regarding this issue has been written and it has been added to the release notes, if needed 👍
+**For Artefactual use:**
+
+Before you close this issue, you must check off the following:
+
+- [ ] All pull requests related to this issue are properly linked
+- [ ] All pull requests related to this issue have been merged
+- [ ] A testing plan for this issue has been implemented and passed (please include testing plan details in the comments below)
+- [ ] Documentation regarding this issue has been written and merged
+- [ ] Details about this issue have been added to the release notes (if applicable)

--- a/.github/ISSUE_TEMPLATE/docs-report-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-report-template.md
@@ -14,3 +14,14 @@ about: Use this template when reporting an issue in the documentation
 
 
 **Suggested fix**
+
+---
+
+**For Artefactual use:**
+
+Before you close this issue, you must check off the following:
+
+- [ ] All pull requests related to this issue are properly linked
+- [ ] All pull requests related to this issue have been merged
+- [ ] Documentation regarding this issue has been written and merged
+- [ ] Details about this issue have been added to the release notes (if applicable)

--- a/.github/ISSUE_TEMPLATE/feature-request-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-template.md
@@ -4,23 +4,26 @@ about: Suggest an idea for this project
 
 ---
 
-**Please describe the problem you'd like to be solved.**
+**Please describe the problem you'd like to be solved**
 
 
-**Describe the solution you'd like to see implemented.**
+**Describe the solution you'd like to see implemented**
 
 
-**Describe alternatives you've considered.**
+**Describe alternatives you've considered**
 
 
 **Additional context**
 
 
 ---
-**For Artefactual use:**
-Please make sure these steps are taken before moving this issue from Review to Done:
 
-- All PRs related to this issue are properly linked 👍
-- All PRs related to this issue have been merged 👍
-- Test plan for this issue has been implemented and passed 👍
-- Documentation regarding this issue has been written and it has been added to the release notes, if needed 👍
+**For Artefactual use:**
+
+Before you close this issue, you must check off the following:
+
+- [ ] All pull requests related to this issue are properly linked
+- [ ] All pull requests related to this issue have been merged
+- [ ] A testing plan for this issue has been implemented and passed (please include testing plan details in the comments below)
+- [ ] Documentation regarding this issue has been written and merged
+- [ ] Details about this issue have been added to the release notes

--- a/.github/ISSUE_TEMPLATE/feature-request-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-template.md
@@ -24,6 +24,6 @@ Before you close this issue, you must check off the following:
 
 - [ ] All pull requests related to this issue are properly linked
 - [ ] All pull requests related to this issue have been merged
-- [ ] A testing plan for this issue has been implemented and passed (please include testing plan details in the comments below)
+- [ ] A testing plan for this issue has been implemented and passed (testing plan information should be included in the issue body or comments)
 - [ ] Documentation regarding this issue has been written and merged
 - [ ] Details about this issue have been added to the release notes


### PR DESCRIPTION
I've turned the checklist at the bottom of the issue templates into an
actual checklist - in GitHub and Codetree, you will be able to see if
all items have been checked off or not.

I've updated the language a little bit as well to be clearer/more
precise.

I have added a note about including a testing plan in the comments of
the issue, but this could maybe be stronger and/or handled differently -
open to suggestions.

I've divided documentation and release notes into two separate
requirements as sometimes one or the other are not really required.

The goal of this is to properly meet our definition of done for issues
before they are closed, because once an issue is closed no one ever
looks at it again.