### PR TITLE
Adds security and title notes to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -1,8 +1,11 @@
 ---
 name: Bug report template
 about: Use this template when reporting a bug
-
 ---
+
+<!--- If this issue relates to a security vulnerability in Archivematica or any of the related repositories, DO NOT file the issue here. Please see the SECURITY.md file at https://github.com/archivematica/Issues for information on how to safely report a security vulnerability. --->
+
+<!--- Please title your issue as a problem statement, starting with "Problem:". Check existing issues for examples. --->
 
 **Expected behaviour**
 

--- a/.github/ISSUE_TEMPLATE/docs-report-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-report-template.md
@@ -1,8 +1,11 @@
 ---
 name: Documentation report template
 about: Use this template when reporting an issue in the documentation
-
 ---
+
+<!--- If this issue relates to a security vulnerability in Archivematica or any of the related repositories, DO NOT file the issue here. Please see the SECURITY.md file at https://github.com/archivematica/Issues for information on how to safely report a security vulnerability. --->
+
+<!--- Please title your issue as a problem statement, starting with "Problem:". Check existing issues for examples. --->
 
 **Version of the documentation**
 

--- a/.github/ISSUE_TEMPLATE/feature-request-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-template.md
@@ -1,8 +1,11 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
+
+<!--- If this issue relates to a security vulnerability in Archivematica or any of the related repositories, DO NOT file the issue here. Please see the SECURITY.md file at https://github.com/archivematica/Issues for information on how to safely report a security vulnerability. --->
+
+<!--- Please title your issue as a problem statement, starting with "Problem:". Check existing issues for examples. --->
 
 **Please describe the problem you'd like to be solved**
 


### PR DESCRIPTION
The security note points reporters to the SECURITY.md file in the repo
for more info on how to safely report security issues.

The title note asks reporters to title the issue as a problem statement.
We could perhaps add more info to this note, but I wanted to keep it
brief.